### PR TITLE
Fix initializecomponent error in form1

### DIFF
--- a/Multiobject_Sorting/Multiobject_Sorting/Form1.cs
+++ b/Multiobject_Sorting/Multiobject_Sorting/Form1.cs
@@ -490,6 +490,20 @@ namespace Multiobject_Sorting
             LoadParameters();
         }
 
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // HSVParameterForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(400, 300);
+            this.Name = "HSVParameterForm";
+            this.Text = "HSV参数设置";
+            this.ResumeLayout(false);
+        }
+
         private void LoadParameters()
         {
             // 这里应该加载参数到界面控件
@@ -512,6 +526,20 @@ namespace Multiobject_Sorting
             InitializeComponent();
         }
 
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // CalibrationPointForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(300, 200);
+            this.Name = "CalibrationPointForm";
+            this.Text = "标定点输入";
+            this.ResumeLayout(false);
+        }
+
         private void OKButton_Click(object sender, EventArgs e)
         {
             // 从文本框获取真实世界坐标
@@ -529,6 +557,20 @@ namespace Multiobject_Sorting
         {
             InitializeComponent();
             plcComm = communication;
+        }
+
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // PLCConfigForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(400, 300);
+            this.Name = "PLCConfigForm";
+            this.Text = "PLC配置";
+            this.ResumeLayout(false);
         }
 
         private async void ConnectButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Add `InitializeComponent()` methods to `HSVParameterForm`, `CalibrationPointForm`, and `PLCConfigForm` to fix CS0103 compilation errors.

These `partial class` forms were calling `InitializeComponent()` without corresponding designer files, leading to a "name does not exist" error. This PR provides basic manual implementations of these methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-4892eaba-ee6f-47ca-a680-bd57b1c9d492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4892eaba-ee6f-47ca-a680-bd57b1c9d492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

